### PR TITLE
OpenFF Protein Dipeptide 2-D TorsionDrive v2.1

### DIFF
--- a/submissions/2021-11-18-OpenFF-Protein-Dipeptide-2D-TorsionDrive/dataset-v2.1-next.json.bz2
+++ b/submissions/2021-11-18-OpenFF-Protein-Dipeptide-2D-TorsionDrive/dataset-v2.1-next.json.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7ea1fd95c4f50c3b1b473ea6028b910355c695b27dce387d9196973874924e1
+size 5790343


### PR DESCRIPTION
<!-- Choose the checklist below based on the type of PR this is -->
<!-- Delete all other checklists -->


## New Submission Checklist

- [x] Created a new folder in the submissions directory containing the dataset
- [x] Added `README.md` describing the dataset see [here](https://github.com/openforcefield/qca-dataset-submission/tree/master/submissions/2020-03-26-OpenFF-Gen-2-Torsion-Set-6-supplemental-2) for examples
- [x] All files used to produce the dataset are included with a description
- [x] Dataset follows the QCSubmit schema defined for [Datasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L340), [OptimizationDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1062) and [TorsionDriveDatasets](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L1225)
- [x] Dataset filename matches pattern `dataset*.json`; may feature a compression extension, such as `.bz2`
- [x] A PDF depicting the molecules is attached, in the case of torsiondrives this should include the highlighting of the central bond, this can be done automatically using [qcsubmit](https://github.com/openforcefield/qcsubmit/blob/56680a7d3298b5d8962edcb840b0fdb34558c053/qcsubmit/datasets.py#L854). 
- [ ] QCSubmit validation passed
- [ ] Made a new dataset entry in the mapping table in repository `README.md`
- [ ] Ready to submit!
